### PR TITLE
feat(OnBootReceiver): remove SDK version check

### DIFF
--- a/app/src/main/java/com/nvllz/stepsy/service/OnBootReceiver.kt
+++ b/app/src/main/java/com/nvllz/stepsy/service/OnBootReceiver.kt
@@ -17,12 +17,8 @@ import android.os.Build
  */
 internal class OnBootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action?.equals(Intent.ACTION_BOOT_COMPLETED, ignoreCase = true) == true) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(Intent(context, MotionService::class.java))
-            } else {
-                context.startService(Intent(context, MotionService::class.java))
-            }
-        }
+        if (intent.action?.equals(Intent.ACTION_BOOT_COMPLETED, ignoreCase = true) != true) return
+
+        context.startForegroundService(Intent(context, MotionService::class.java))
     }
 }


### PR DESCRIPTION
Removes unnecessary SDK check since minimum project SDK version is 26. Feel free to close if this behaviour is intended to support legacy devices, as I was basing the pull request off the build.gradle minSdk.