### PR TITLE
Make widget styles compatible with Android 12 widget system

### DIFF
--- a/app/src/main/res/drawable/widget_bg.xml
+++ b/app/src/main/res/drawable/widget_bg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/widgetBackground"/>
-    <corners android:radius="12dp"/>
+    <corners android:radius="@dimen/widgetRoundness"/>
 </shape>

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="widgetPrimary">@android:color/system_accent1_100</color>
+    <color name="widgetSecondary">@android:color/system_neutral1_200</color>
+    <color name="widgetBackground">@android:color/system_accent2_800</color>
+</resources>

--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="widgetPrimary">@android:color/system_accent1_600</color>
+    <color name="widgetSecondary">@android:color/system_neutral1_800</color>
+    <color name="widgetBackground">@android:color/system_accent2_50</color>
+</resources>

--- a/app/src/main/res/values-v31/dimens.xml
+++ b/app/src/main/res/values-v31/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="widgetRoundness">@android:dimen/system_app_widget_background_radius</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="widgetRoundness">12dp</dimen>
+</resources>


### PR DESCRIPTION
This uses Android 12 compatible coloring and dimens to provide a style compatible with Android 12 widget system while keeping the old system for older Android versions.

I understand if you don't like this per https://github.com/nvllz/stepsy/issues/11#issuecomment-2824947842 just if you want to reconsider it this takes care of it and makes it similar to Android's own Clock widget (above left),

<img width="321" alt="image" src="https://github.com/user-attachments/assets/4da76bb4-4cc3-42e0-a432-3e86e1ffb8d5" />

<img width="319" alt="image" src="https://github.com/user-attachments/assets/fb14c579-5e3d-48da-b7fc-a63cc99ce3ef" />

<img width="324" alt="image" src="https://github.com/user-attachments/assets/2b3e9bcf-b403-4811-982c-c8a45a2b0a98" />

<img width="326" alt="image" src="https://github.com/user-attachments/assets/50618efd-8b77-47de-a834-02915fef7bf7" />
